### PR TITLE
refactor: export presets that support flat config and legacy config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,6 +6,9 @@ const config = {
         es2024: true,
         node: true,
     },
+    ignorePatterns: [
+        "examples",
+    ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaVersion: "latest",

--- a/README.md
+++ b/README.md
@@ -33,22 +33,19 @@ bun add --dev @eslint-react/eslint-plugin
 
 ## Usage
 
-### [`.eslintrc`](https://eslint.org/docs/latest/use/configure/configuration-files)
+### [`.eslintrc.cjs`](https://eslint.org/docs/latest/use/configure/configuration-files)
 
-```json
-{
-    "parser": "@typescript-eslint/parser",
-    "extends": [
-        "plugin:@typescript-eslint/recommended",
-        "plugin:@eslint-react/recommended"
-    ],
-    "plugins": [
-        "@typescript-eslint",
-        "@eslint-react"
-    ],
-    "rules": {
-        "@eslint-react/<rule-name>": "error"
-    }
+```cjs
+module.exports = {
+  root: true,
+  env: { browser: true, es2020: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    "plugin:@eslint-react/recommended",
+  ],
+  ignorePatterns: ['dist', '.eslintrc.cjs'],
+  parser: '@typescript-eslint/parser',
 }
 ```
 
@@ -67,14 +64,13 @@ export default [
         },
         plugins: {
             "@typescript-eslint": ts,
-            "@eslint-react": react,
         },
         rules: {
             ...ts.configs["eslint-recommended"].rules,
             ...ts.configs["recommended"].rules,
         },
     },
-    react.configs.recommended,
+    react.configs["flat/recommended"],
 ];
 ```
 

--- a/examples/flat-config-recommended/.gitignore
+++ b/examples/flat-config-recommended/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/flat-config-recommended/eslint.config.js
+++ b/examples/flat-config-recommended/eslint.config.js
@@ -1,0 +1,20 @@
+import ts from "@typescript-eslint/eslint-plugin";
+import tsParser from "@typescript-eslint/parser";
+import react from "@eslint-react/eslint-plugin";
+
+export default [
+    {
+        files: ["**/*.{ts,tsx}"],
+        languageOptions: {
+            parser: tsParser,
+        },
+        plugins: {
+            "@typescript-eslint": ts,
+        },
+        rules: {
+            ...ts.configs["eslint-recommended"].rules,
+            ...ts.configs["recommended"].rules,
+        },
+    },
+    react.configs["flat/recommended"],
+];

--- a/examples/flat-config-recommended/index.html
+++ b/examples/flat-config-recommended/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/flat-config-recommended/package.json
+++ b/examples/flat-config-recommended/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "flat-config-recommended",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "tsc && vite build",
+        "lint": "eslint .",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@eslint-react/eslint-plugin": "workspace:*",
+        "@types/react": "^18.2.15",
+        "@types/react-dom": "^18.2.7",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "@vitejs/plugin-react": "^4.0.3",
+        "eslint": "^8.45.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-refresh": "^0.4.3",
+        "typescript": "^5.0.2",
+        "vite": "^4.4.5"
+    }
+}

--- a/examples/flat-config-recommended/src/main.tsx
+++ b/examples/flat-config-recommended/src/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+function Step() {
+    return [0, 1, 2].map((_, index) => <div key={index}>Step {index}</div>);
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+        <Step />
+    </React.StrictMode>,
+);

--- a/examples/flat-config-recommended/tsconfig.json
+++ b/examples/flat-config-recommended/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+
+        /* Bundler mode */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"],
+    "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/flat-config-recommended/tsconfig.node.json
+++ b/examples/flat-config-recommended/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "composite": true,
+        "skipLibCheck": true,
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true
+    },
+    "include": ["vite.config.ts"]
+}

--- a/examples/flat-config-recommended/vite.config.ts
+++ b/examples/flat-config-recommended/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [react()],
+});

--- a/examples/legacy-config-recommended/.eslintrc.cjs
+++ b/examples/legacy-config-recommended/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+    root: true,
+    env: { browser: true, es2020: true },
+    extends: [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@eslint-react/recommended",
+    ],
+    ignorePatterns: ["dist", ".eslintrc.cjs"],
+    parser: "@typescript-eslint/parser",
+};

--- a/examples/legacy-config-recommended/.gitignore
+++ b/examples/legacy-config-recommended/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/examples/legacy-config-recommended/index.html
+++ b/examples/legacy-config-recommended/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + React + TS</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/legacy-config-recommended/package.json
+++ b/examples/legacy-config-recommended/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "legacy-config-recommended",
+    "private": true,
+    "version": "0.0.0",
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "tsc && vite build",
+        "lint": "eslint src",
+        "preview": "vite preview"
+    },
+    "dependencies": {
+        "@eslint-react/eslint-plugin": "workspace:*",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+    },
+    "devDependencies": {
+        "@types/react": "^18.2.15",
+        "@types/react-dom": "^18.2.7",
+        "@typescript-eslint/eslint-plugin": "^6.0.0",
+        "@typescript-eslint/parser": "^6.0.0",
+        "@vitejs/plugin-react": "^4.0.3",
+        "eslint": "^8.45.0",
+        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-refresh": "^0.4.3",
+        "typescript": "^5.0.2",
+        "vite": "^4.4.5"
+    }
+}

--- a/examples/legacy-config-recommended/src/main.tsx
+++ b/examples/legacy-config-recommended/src/main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+function Step() {
+    return [0, 1, 2].map((_, index) => <div key={index}>Step {index}</div>);
+}
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+        <Step />
+    </React.StrictMode>,
+);

--- a/examples/legacy-config-recommended/src/vite-env.d.ts
+++ b/examples/legacy-config-recommended/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/legacy-config-recommended/tsconfig.json
+++ b/examples/legacy-config-recommended/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "target": "ES2020",
+        "useDefineForClassFields": true,
+        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "module": "ESNext",
+        "skipLibCheck": true,
+
+        /* Bundler mode */
+        "moduleResolution": "bundler",
+        "allowImportingTsExtensions": true,
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "noEmit": true,
+        "jsx": "react-jsx",
+
+        /* Linting */
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noFallthroughCasesInSwitch": true
+    },
+    "include": ["src"],
+    "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/legacy-config-recommended/tsconfig.node.json
+++ b/examples/legacy-config-recommended/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "composite": true,
+        "skipLibCheck": true,
+        "module": "ESNext",
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true
+    },
+    "include": ["vite.config.ts"]
+}

--- a/examples/legacy-config-recommended/vite.config.ts
+++ b/examples/legacy-config-recommended/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+// https://vitejs.dev/config/
+export default defineConfig({
+    plugins: [react()],
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "author": "Eva1ent<let@ik.me>",
     "scripts": {
         "prepare": "husky install",
-        "build": "turbo build",
+        "build": "turbo build --filter='./packages/*'",
         "build:manual": "bun run ./scripts/build.ts",
         "build:docs": "pnpm --filter \"@eslint-react/*\" run build:docs",
         "format:check": "dprint check",

--- a/packages/eslint-plugin-debug/src/index.ts
+++ b/packages/eslint-plugin-debug/src/index.ts
@@ -8,5 +8,5 @@ export { name } from "../package.json";
 
 export const rules = {
     "class-component": debugClassComponent,
-    "debug/function-component": debugFunctionComponent,
+    "function-component": debugFunctionComponent,
 } as const;

--- a/packages/eslint-plugin-debug/src/rules/class-component.ts
+++ b/packages/eslint-plugin-debug/src/rules/class-component.ts
@@ -4,7 +4,7 @@ import { createRule } from "@eslint-react/shared";
 import { E } from "@eslint-react/tools";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 
-export const RULE_NAME = "debug/class-component";
+export const RULE_NAME = "class-component";
 
 type MessageID = "CLASS_COMPONENT";
 

--- a/packages/eslint-plugin-debug/src/rules/function-component.ts
+++ b/packages/eslint-plugin-debug/src/rules/function-component.ts
@@ -4,7 +4,7 @@ import { createRule } from "@eslint-react/shared";
 import { E } from "@eslint-react/tools";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 
-export const RULE_NAME = "debug/function-component";
+export const RULE_NAME = "function-component";
 
 type MessageID = "FUNCTION_COMPONENT" | "POSSIBLE_FUNCTION_COMPONENT";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-array-index-key.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-array-index-key.ts
@@ -8,7 +8,7 @@ import type { ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { isMatching } from "ts-pattern";
 
-export const RULE_NAME = "jsx/no-array-index-key";
+export const RULE_NAME = "no-array-index-key";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.ts
@@ -16,7 +16,7 @@ import type { ESLintUtils } from "@typescript-eslint/utils";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { isMatching, match } from "ts-pattern";
 
-export const RULE_NAME = "jsx/no-duplicate-key";
+export const RULE_NAME = "no-duplicate-key";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
@@ -4,7 +4,7 @@ import { createRule } from "@eslint-react/shared";
 import { type TSESTree } from "@typescript-eslint/types";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 
-export const RULE_NAME = "jsx/no-leaked-conditional-rendering";
+export const RULE_NAME = "no-leaked-conditional-rendering";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-missing-key.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-missing-key.ts
@@ -8,7 +8,7 @@ import type { ESLintUtils } from "@typescript-eslint/utils";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import { match } from "ts-pattern";
 
-export const RULE_NAME = "jsx/no-missing-key";
+export const RULE_NAME = "no-missing-key";
 
 type MessageID = "INVALID" | "INVALID_FRAGMENT";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.ts
@@ -4,7 +4,7 @@ import { type TSESTree } from "@typescript-eslint/types";
 import { AST_NODE_TYPES as N } from "@typescript-eslint/types";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 
-export const RULE_NAME = "jsx/no-misused-comment-in-textnode";
+export const RULE_NAME = "no-misused-comment-in-textnode";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-jsx/src/rules/no-script-url.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-script-url.ts
@@ -3,7 +3,7 @@ import { createRule } from "@eslint-react/shared";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 import { getStaticValue } from "@typescript-eslint/utils/ast-utils";
 
-export const RULE_NAME = "jsx/no-script-url";
+export const RULE_NAME = "no-script-url";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.ts
+++ b/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.ts
@@ -3,7 +3,7 @@ import { getPropName } from "@eslint-react/jsx";
 import { createRule } from "@eslint-react/shared";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 
-export const RULE_NAME = "jsx/prefer-shorthand-boolean";
+export const RULE_NAME = "prefer-shorthand-boolean";
 
 type MessageID = "INVALID";
 

--- a/packages/eslint-plugin-naming-convention/src/index.ts
+++ b/packages/eslint-plugin-naming-convention/src/index.ts
@@ -7,6 +7,6 @@ import namingConventionFilenameExtension from "./rules/filename-extension";
 export { name } from "../package.json";
 
 export const rules = {
-    "naming-convention/filename": namingConventionFilename,
-    "naming-convention/filename-extension": namingConventionFilenameExtension,
+    filename: namingConventionFilename,
+    "filename-extension": namingConventionFilenameExtension,
 } as const;

--- a/packages/eslint-plugin-naming-convention/src/rules/filename-extension.ts
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename-extension.ts
@@ -4,7 +4,7 @@ import type { TSESTree } from "@typescript-eslint/types";
 import type { ESLintUtils } from "@typescript-eslint/utils";
 import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
 
-export const RULE_NAME = "naming-convention/filename-extension";
+export const RULE_NAME = "filename-extension";
 
 type MessageID = "INVALID" | "UNEXPECTED";
 

--- a/packages/eslint-plugin-naming-convention/src/rules/filename.ts
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename.ts
@@ -5,7 +5,7 @@ import type { JSONSchema4 } from "@typescript-eslint/utils/json-schema";
 import type { ReportDescriptor } from "@typescript-eslint/utils/ts-eslint";
 import path from "pathe";
 
-export const RULE_NAME = "naming-convention/filename";
+export const RULE_NAME = "filename";
 
 type MessageID = "FILENAME_CASE_MISMATCH" | "FILENAME_CASE_MISMATCH_SUGGESTION" | "FILENAME_EMPTY";
 

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -27,27 +27,8 @@
     "exports": {
         ".": {
             "require": "./dist/index.js",
-            "import": "./dist/index.mjs"
-        },
-        "./configs/all": {
-            "require": "./dist/configs/all.js",
-            "import": "./dist/configs/all.mjs"
-        },
-        "./configs/off": {
-            "require": "./dist/configs/off.js",
-            "import": "./dist/configs/off.mjs"
-        },
-        "./configs/debug": {
-            "require": "./dist/configs/debug.js",
-            "import": "./dist/configs/debug.mjs"
-        },
-        "./configs/recommended": {
-            "require": "./dist/configs/recommended.js",
-            "import": "./dist/configs/recommended.mjs"
-        },
-        "./configs/recommended-type-checked": {
-            "require": "./dist/configs/recommended-type-checked.js",
-            "import": "./dist/configs/recommended-type-checked.mjs"
+            "import": "./dist/index.mjs",
+            "types": "./dist/index.d.ts"
         },
         "./package.json": "./package.json"
     },

--- a/packages/eslint-plugin/rollup.config.ts
+++ b/packages/eslint-plugin/rollup.config.ts
@@ -43,8 +43,6 @@ const options = {
     ],
 } satisfies RollupOptions;
 
-const configs = ["all", "off", "recommended", "recommended-type-checked", "debug"] as const;
-
 export default defineConfig([
     {
         ...options,
@@ -55,15 +53,6 @@ export default defineConfig([
             { file: "dist/index.mjs", format: "esm" },
         ],
     },
-    ...configs.map(name => ({
-        ...options,
-        input: `src/configs/${name}.ts`,
-        output: [
-            { file: `dist/configs/${name}.cjs`, format: "cjs" },
-            { file: `dist/configs/${name}.js`, format: "cjs" },
-            { file: `dist/configs/${name}.mjs`, format: "esm" },
-        ],
-    } satisfies RollupOptions)),
     {
         ...options,
         input: "src/index.ts",

--- a/packages/eslint-plugin/src/configs/all.ts
+++ b/packages/eslint-plugin/src/configs/all.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs.all.rules,
-};

--- a/packages/eslint-plugin/src/configs/debug.ts
+++ b/packages/eslint-plugin/src/configs/debug.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs.debug.rules,
-};

--- a/packages/eslint-plugin/src/configs/jsx.ts
+++ b/packages/eslint-plugin/src/configs/jsx.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs.jsx.rules,
-};

--- a/packages/eslint-plugin/src/configs/off.ts
+++ b/packages/eslint-plugin/src/configs/off.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs.off.rules,
-};

--- a/packages/eslint-plugin/src/configs/recommended-type-checked.ts
+++ b/packages/eslint-plugin/src/configs/recommended-type-checked.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs["recommended-type-checked"].rules,
-};

--- a/packages/eslint-plugin/src/configs/recommended.ts
+++ b/packages/eslint-plugin/src/configs/recommended.ts
@@ -1,8 +1,0 @@
-import mod from "../index";
-
-export default {
-    plugins: {
-        "@eslint-react": mod,
-    },
-    rules: mod.configs.recommended.rules,
-};

--- a/packages/eslint-plugin/src/index.ts
+++ b/packages/eslint-plugin/src/index.ts
@@ -20,12 +20,12 @@ const rules = {
     "jsx/prefer-shorthand-boolean": "warn",
     "naming-convention/filename": "warn",
     "naming-convention/filename-extension": "warn",
-    "no-constructed-context-value": "error",
-    "no-dangerously-set-innerhtml": "error",
-    "no-dangerously-set-innerhtml-with-children": "error",
-    "no-string-refs": "error",
-    "no-unstable-default-props": "error",
-    "no-unstable-nested-components": "error",
+    "react/no-constructed-context-value": "error",
+    "react/no-dangerously-set-innerhtml": "error",
+    "react/no-dangerously-set-innerhtml-with-children": "error",
+    "react/no-string-refs": "error",
+    "react/no-unstable-default-props": "error",
+    "react/no-unstable-nested-components": "error",
 } as const satisfies RulePreset;
 
 const rulesEntries = Object.entries(rules);
@@ -38,12 +38,12 @@ const recommendedRules = {
     "jsx/no-misused-comment-in-textnode": "warn",
     "jsx/no-script-url": "error",
     "jsx/prefer-shorthand-boolean": "warn",
-    "no-constructed-context-value": "error",
-    "no-dangerously-set-innerhtml": "error",
-    "no-dangerously-set-innerhtml-with-children": "error",
-    "no-string-refs": "error",
-    "no-unstable-default-props": "error",
-    "no-unstable-nested-components": "error",
+    "react/no-constructed-context-value": "error",
+    "react/no-dangerously-set-innerhtml": "error",
+    "react/no-dangerously-set-innerhtml-with-children": "error",
+    "react/no-string-refs": "error",
+    "react/no-unstable-default-props": "error",
+    "react/no-unstable-nested-components": "error",
 } as const satisfies RulePreset;
 
 const allRules: RulePreset = Object.fromEntries(rulesEntries.filter(([key]) => !key.startsWith("debug/")));
@@ -51,10 +51,33 @@ const offRules: RulePreset = Object.fromEntries(rulesEntries.map(([key]) => [key
 const jsxRules: RulePreset = Object.fromEntries(rulesEntries.filter(([key]) => key.startsWith("jsx/")));
 const debugRules: RulePreset = Object.fromEntries(rulesEntries.filter(([key]) => key.startsWith("debug/")));
 
+const plugins = {
+    "@eslint-react/debug": debug,
+    "@eslint-react/hooks": hooks,
+    "@eslint-react/jsx": jsx,
+    "@eslint-react/naming-convention": namingConvention,
+    "@eslint-react/react": react,
+} as const;
+
+const createRules = (rules: RulePreset) =>
+    Object.fromEntries(Object.entries(rules).map(([key, value]) => [`@eslint-react/${key}`, value]));
+
 const createConfig = (rules: RulePreset) => {
     return {
-        rules: Object.fromEntries(Object.entries(rules).map(([key, value]) => [`@eslint-react/${key}`, value])),
+        plugins: ["@eslint-react"],
+        rules: createRules(rules),
     };
+};
+
+const createFlatConfig = (rules: RulePreset) => {
+    return {
+        plugins,
+        rules: createRules(rules),
+    };
+};
+
+const createRulesWithPrefix = (rules: Record<string, unknown>, prefix: string) => {
+    return Object.fromEntries(Object.entries(rules).map(([key, value]) => [`${prefix}/${key}`, value]));
 };
 
 export default {
@@ -62,18 +85,22 @@ export default {
     configs: {
         all: createConfig(allRules),
         debug: createConfig(debugRules),
+        "flat/all": createFlatConfig(allRules),
+        "flat/debug": createFlatConfig(debugRules),
+        "flat/jsx": createFlatConfig(jsxRules),
+        "flat/off": createFlatConfig(offRules),
+        "flat/recommended": createFlatConfig(recommendedRules),
+        "flat/recommended-type-checked": createFlatConfig(recommendedRules),
         jsx: createConfig(jsxRules),
         off: createConfig(offRules),
         recommended: createConfig(recommendedRules),
         "recommended-type-checked": createConfig(recommendedRules),
     },
-    plugins: {
-        "@eslint-react": debug,
-        "@eslint-react-hooks": hooks,
-        "@eslint-react-jsx": jsx,
-        "@eslint-react-naming-convention": namingConvention,
-    },
     rules: {
-        ...react.rules,
+        ...createRulesWithPrefix(debug.rules, "debug"),
+        ...createRulesWithPrefix(hooks.rules, "hooks"),
+        ...createRulesWithPrefix(jsx.rules, "jsx"),
+        ...createRulesWithPrefix(namingConvention.rules, "naming-convention"),
+        ...createRulesWithPrefix(react.rules, "react"),
     },
 } as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,92 @@ importers:
         specifier: 0.34.6
         version: 0.34.6
 
+  examples/flat-config-recommended:
+    dependencies:
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@eslint-react/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../packages/eslint-plugin
+      '@types/react':
+        specifier: ^18.2.15
+        version: 18.2.31
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.14
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.0.0
+        version: 6.9.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.3.0-beta)
+      '@typescript-eslint/parser':
+        specifier: '>=6.9.0'
+        version: 6.9.0(eslint@8.52.0)(typescript@5.3.0-beta)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.3
+        version: 4.1.0(vite@4.5.0)
+      eslint:
+        specifier: '>=8.52.0'
+        version: 8.52.0
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.0(eslint@8.52.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.3
+        version: 0.4.3(eslint@8.52.0)
+      typescript:
+        specifier: beta
+        version: 5.3.0-beta
+      vite:
+        specifier: ^4.4.5
+        version: 4.5.0(@types/node@20.8.7)
+
+  examples/legacy-config-recommended:
+    dependencies:
+      '@eslint-react/eslint-plugin':
+        specifier: workspace:*
+        version: link:../../packages/eslint-plugin
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@types/react':
+        specifier: ^18.2.15
+        version: 18.2.31
+      '@types/react-dom':
+        specifier: ^18.2.7
+        version: 18.2.14
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.0.0
+        version: 6.9.0(@typescript-eslint/parser@6.9.0)(eslint@8.52.0)(typescript@5.3.0-beta)
+      '@typescript-eslint/parser':
+        specifier: '>=6.9.0'
+        version: 6.9.0(eslint@8.52.0)(typescript@5.3.0-beta)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.3
+        version: 4.1.0(vite@4.5.0)
+      eslint:
+        specifier: '>=8.52.0'
+        version: 8.52.0
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.0(eslint@8.52.0)
+      eslint-plugin-react-refresh:
+        specifier: ^0.4.3
+        version: 0.4.3(eslint@8.52.0)
+      typescript:
+        specifier: beta
+        version: 5.3.0-beta
+      vite:
+        specifier: ^4.4.5
+        version: 4.5.0(@types/node@20.8.7)
+
   packages/eslint-plugin:
     dependencies:
       '@eslint-react/eslint-plugin-debug':
@@ -1232,6 +1318,26 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/plugin-transform-react-jsx': 7.22.15(@babel/core@7.23.2)
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.23.2):
+    resolution: {integrity: sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.23.2):
+    resolution: {integrity: sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
   /@babel/plugin-transform-react-jsx@7.22.15(@babel/core@7.23.2):
@@ -2770,6 +2876,35 @@ packages:
       minimatch: 9.0.3
     dev: true
 
+  /@types/babel__core@7.20.3:
+    resolution: {integrity: sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==}
+    dependencies:
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      '@types/babel__generator': 7.6.6
+      '@types/babel__template': 7.4.3
+      '@types/babel__traverse': 7.20.3
+    dev: true
+
+  /@types/babel__generator@7.6.6:
+    resolution: {integrity: sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
+  /@types/babel__template@7.4.3:
+    resolution: {integrity: sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==}
+    dependencies:
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+    dev: true
+
+  /@types/babel__traverse@7.20.3:
+    resolution: {integrity: sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==}
+    dependencies:
+      '@babel/types': 7.23.0
+    dev: true
+
   /@types/chai-subset@1.3.4:
     resolution: {integrity: sha512-CCWNXrJYSUIojZ1149ksLl3AN9cmZ5djf+yUoVVV+NuYrtydItQVlL2ZDqyC6M6O9LWRnVf8yYDxbXHO2TfQZg==}
     dependencies:
@@ -2811,8 +2946,30 @@ packages:
     resolution: {integrity: sha512-3YmXzzPAdOTVljVMkTMBdBEvlOLg2cDQaDhnnhT3nT9uDbnJzjWhKlzb+desT12Y7tGqaN6d+AbozcKzyL36Ng==}
     dev: true
 
+  /@types/prop-types@15.7.9:
+    resolution: {integrity: sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==}
+    dev: true
+
+  /@types/react-dom@18.2.14:
+    resolution: {integrity: sha512-V835xgdSVmyQmI1KLV2BEIUgqEuinxp9O4G6g3FqO/SqLac049E53aysv0oEFD2kHfejeKU+ZqL2bcFWj9gLAQ==}
+    dependencies:
+      '@types/react': 18.2.31
+    dev: true
+
+  /@types/react@18.2.31:
+    resolution: {integrity: sha512-c2UnPv548q+5DFh03y8lEDeMfDwBn9G3dRwfkrxQMo/dOtRHUUO57k6pHvBIfH/VF4Nh+98mZ5aaSe+2echD5g==}
+    dependencies:
+      '@types/prop-types': 15.7.9
+      '@types/scheduler': 0.16.5
+      csstype: 3.1.2
+    dev: true
+
   /@types/resolve@1.20.2:
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+    dev: true
+
+  /@types/scheduler@0.16.5:
+    resolution: {integrity: sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==}
     dev: true
 
   /@types/semver@7.5.4:
@@ -3023,6 +3180,22 @@ packages:
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
+
+  /@vitejs/plugin-react@4.1.0(vite@4.5.0):
+    resolution: {integrity: sha512-rM0SqazU9iqPUraQ2JlIvReeaxOoRj6n+PzB1C0cBzIbd8qP336nC39/R9yPi3wVcah7E7j/kdU1uCUqMEU4OQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.23.2)
+      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.23.2)
+      '@types/babel__core': 7.20.3
+      react-refresh: 0.14.0
+      vite: 4.5.0(@types/node@20.8.7)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@vitest/expect@0.34.6:
     resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
@@ -3926,6 +4099,10 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
+
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
     dev: true
 
   /data-uri-to-buffer@3.0.1:
@@ -5482,7 +5659,6 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     requiresBuild: true
-    dev: true
 
   /js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -5698,6 +5874,13 @@ packages:
       chalk: 5.3.0
       is-unicode-supported: 1.3.0
     dev: true
+
+  /loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+    dependencies:
+      js-tokens: 4.0.0
+    dev: false
 
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -6716,9 +6899,31 @@ packages:
   /rambda@8.5.0:
     resolution: {integrity: sha512-+bh+mA8Z2iL8fQR8iEvg04bhjlGcFNPaDkI1bDsbp/SQS8Oz29eA5LtdBDdii8tna1SGBMRNkZJ7tNJW/31K4Q==}
 
+  /react-dom@18.2.0(react@18.2.0):
+    resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
+    peerDependencies:
+      react: ^18.2.0
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.2.0
+      scheduler: 0.23.0
+    dev: false
+
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
+
+  /react-refresh@0.14.0:
+    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /react@18.2.0:
+    resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
@@ -7009,6 +7214,12 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
+
+  /scheduler@0.23.0:
+    resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
+    dependencies:
+      loose-envify: 1.4.0
+    dev: false
 
   /scslre@0.3.0:
     resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}


### PR DESCRIPTION
In this PR, I

1. remove rule name prefix in parent packages
2. export correct preset in `eslint-plugin` package
3. add two examples to test flat config and leagcy config

fix #8 #10