### PR TITLE
docs: fix automatic document generation for multiple packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,45 +80,46 @@ export default [
 
 💼 Configurations enabled in.\
 ⚠️ Configurations set to warn in.\
+🚫 Configurations disabled in.\
 🎨 Set in the `jsx` configuration.\
 👍 Set in the `recommended` configuration.
 
 ### debug
 
-| Name                                                                                      | Description                                               | 💼 | ⚠️  |
-| :---------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :- |
-| [debug/class-component](packages/eslint-plugin/docs/rules/debug/class-component.md)       | reports all class components, including anonymous ones    |    |    |
-| [debug/function-component](packages/eslint-plugin/docs/rules/debug/function-component.md) | reports all function components, including anonymous ones |    |    |
+| Name                                                                                     | Description                                               | 💼 | ⚠️                       | 🚫                    |
+| :--------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :---------------------- | :-------------------- |
+| [debug/class-component](packages/eslint-plugin-debug/src/rules/class-component.md)       | reports all class components, including anonymous ones    |    | ![badge-debug-legacy][] | ![badge-off-legacy][] |
+| [debug/function-component](packages/eslint-plugin-debug/src/rules/function-component.md) | reports all function components, including anonymous ones |    | ![badge-debug-legacy][] | ![badge-off-legacy][] |
 
 ### jsx
 
-| Name                                                                                                            | Description                                                   | 💼    | ⚠️     |
-| :-------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :---- | :---- |
-| [jsx/no-array-index-key](packages/eslint-plugin/docs/rules/jsx/no-array-index-key.md)                           | disallow using Array index as key                             | 🎨 👍 |       |
-| [jsx/no-duplicate-key](packages/eslint-plugin/docs/rules/jsx/no-duplicate-key.md)                               | disallow duplicate keys in `key` prop when rendering list     | 🎨 👍 |       |
-| [jsx/no-leaked-conditional-rendering](packages/eslint-plugin/docs/rules/jsx/no-leaked-conditional-rendering.md) | disallow problematic leaked values from being rendered        | 🎨 👍 |       |
-| [jsx/no-missing-key](packages/eslint-plugin/docs/rules/jsx/no-missing-key.md)                                   | require `key` prop when rendering list                        | 🎨 👍 |       |
-| [jsx/no-misused-comment-in-textnode](packages/eslint-plugin/docs/rules/jsx/no-misused-comment-in-textnode.md)   | disallow comments from being inserted as text nodes           |       | 🎨 👍 |
-| [jsx/no-script-url](packages/eslint-plugin/docs/rules/jsx/no-script-url.md)                                     | disallow `javascript:` URLs as JSX event handler prop's value | 👍    |       |
-| [jsx/prefer-shorthand-boolean](packages/eslint-plugin/docs/rules/jsx/prefer-shorthand-boolean.md)               | enforce boolean attributes notation in JSX                    |       | 🎨 👍 |
+| Name                                                                                                           | Description                                                   | 💼                                                                                                                         | ⚠️                                                                                                                          | 🚫                    |
+| :------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :-------------------- |
+| [jsx/no-array-index-key](packages/eslint-plugin-jsx/src/rules/no-array-index-key.md)                           | disallow using Array index as key                             | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
+| [jsx/no-duplicate-key](packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md)                               | disallow duplicate keys in `key` prop when rendering list     | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
+| [jsx/no-leaked-conditional-rendering](packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md) | disallow problematic leaked values from being rendered        | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
+| [jsx/no-missing-key](packages/eslint-plugin-jsx/src/rules/no-missing-key.md)                                   | require `key` prop when rendering list                        | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
+| [jsx/no-misused-comment-in-textnode](packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md)   | disallow comments from being inserted as text nodes           |                                                                                                                            | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] | ![badge-off-legacy][] |
+| [jsx/no-script-url](packages/eslint-plugin-jsx/src/rules/no-script-url.md)                                     | disallow `javascript:` URLs as JSX event handler prop's value | 👍 ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][]                                                |                                                                                                                            |                       |
+| [jsx/prefer-shorthand-boolean](packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md)               | enforce boolean attributes notation in JSX                    |                                                                                                                            | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] | ![badge-off-legacy][] |
 
 ### naming-convention
 
-| Name                                                                                                              | Description                                        | 💼 | ⚠️  |
-| :---------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- | :- | :- |
-| [naming-convention/filename](packages/eslint-plugin/docs/rules/naming-convention/filename.md)                     | enforce naming convention for JSX file names       |    |    |
-| [naming-convention/filename-extension](packages/eslint-plugin/docs/rules/naming-convention/filename-extension.md) | enforces naming convention for JSX file extensions |    |    |
+| Name                                                                                                             | Description                                        | 💼 | ⚠️                     | 🚫                    |
+| :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- | :- | :-------------------- | :-------------------- |
+| [naming-convention/filename](packages/eslint-plugin-naming-convention/src/rules/filename.md)                     | enforce naming convention for JSX file names       |    | ![badge-all-legacy][] | ![badge-off-legacy][] |
+| [naming-convention/filename-extension](packages/eslint-plugin-naming-convention/src/rules/filename-extension.md) | enforces naming convention for JSX file extensions |    | ![badge-all-legacy][] | ![badge-off-legacy][] |
 
 ### react
 
-| Name                                                                                                                          | Description                                                                     | 💼 | ⚠️  |
-| :---------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :- | :- |
-| [no-constructed-context-value](packages/eslint-plugin/docs/rules/no-constructed-context-value.md)                             | disallows passing constructed values to context providers                       | 👍 |    |
-| [no-dangerously-set-innerhtml](packages/eslint-plugin/docs/rules/no-dangerously-set-innerhtml.md)                             | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 |    |
-| [no-dangerously-set-innerhtml-with-children](packages/eslint-plugin/docs/rules/no-dangerously-set-innerhtml-with-children.md) | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 |    |
-| [no-string-refs](packages/eslint-plugin/docs/rules/no-string-refs.md)                                                         | disallow using deprecated string refs                                           | 👍 |    |
-| [no-unstable-default-props](packages/eslint-plugin/docs/rules/no-unstable-default-props.md)                                   | disallow usage of unstable value as default param in function component         | 👍 |    |
-| [no-unstable-nested-components](packages/eslint-plugin/docs/rules/no-unstable-nested-components.md)                           | disallow usage of unstable nested components                                    | 👍 |    |
+| Name                                                                                                                                     | Description                                                                     | 💼                                                                                                | ⚠️  | 🚫                    |
+| :--------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------ | :- | :-------------------- |
+| [react/no-constructed-context-value](packages/eslint-plugin-react/src/rules/no-constructed-context-value.md)                             | disallows passing constructed values to context providers                       | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| [react/no-dangerously-set-innerhtml](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md)                             | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| [react/no-dangerously-set-innerhtml-with-children](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md) | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| [react/no-string-refs](packages/eslint-plugin-react/src/rules/no-string-refs.md)                                                         | disallow using deprecated string refs                                           | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| [react/no-unstable-default-props](packages/eslint-plugin-react/src/rules/no-unstable-default-props.md)                                   | disallow usage of unstable value as default param in function component         | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| [react/no-unstable-nested-components](packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md)                           | disallow usage of unstable nested components                                    | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
 
 <!-- end auto-generated rules list -->
 

--- a/README.md
+++ b/README.md
@@ -80,46 +80,45 @@ export default [
 
 💼 Configurations enabled in.\
 ⚠️ Configurations set to warn in.\
-🚫 Configurations disabled in.\
-🎨 Set in the `jsx` configuration.\
-👍 Set in the `recommended` configuration.
+🎨 Set in the `jsx-legacy` configuration.\
+👍 Set in the `recommended-legacy` configuration.
 
 ### debug
 
-| Name                                                                                     | Description                                               | 💼 | ⚠️                       | 🚫                    |
-| :--------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :---------------------- | :-------------------- |
-| [debug/class-component](packages/eslint-plugin-debug/src/rules/class-component.md)       | reports all class components, including anonymous ones    |    | ![badge-debug-legacy][] | ![badge-off-legacy][] |
-| [debug/function-component](packages/eslint-plugin-debug/src/rules/function-component.md) | reports all function components, including anonymous ones |    | ![badge-debug-legacy][] | ![badge-off-legacy][] |
+| Name                                                                                     | Description                                               | 💼 | ⚠️  |
+| :--------------------------------------------------------------------------------------- | :-------------------------------------------------------- | :- | :- |
+| [debug/class-component](packages/eslint-plugin-debug/src/rules/class-component.md)       | reports all class components, including anonymous ones    |    |    |
+| [debug/function-component](packages/eslint-plugin-debug/src/rules/function-component.md) | reports all function components, including anonymous ones |    |    |
 
 ### jsx
 
-| Name                                                                                                           | Description                                                   | 💼                                                                                                                         | ⚠️                                                                                                                          | 🚫                    |
-| :------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------- | :-------------------- |
-| [jsx/no-array-index-key](packages/eslint-plugin-jsx/src/rules/no-array-index-key.md)                           | disallow using Array index as key                             | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
-| [jsx/no-duplicate-key](packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md)                               | disallow duplicate keys in `key` prop when rendering list     | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
-| [jsx/no-leaked-conditional-rendering](packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md) | disallow problematic leaked values from being rendered        | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
-| [jsx/no-missing-key](packages/eslint-plugin-jsx/src/rules/no-missing-key.md)                                   | require `key` prop when rendering list                        | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |                                                                                                                            | ![badge-off-legacy][] |
-| [jsx/no-misused-comment-in-textnode](packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md)   | disallow comments from being inserted as text nodes           |                                                                                                                            | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] | ![badge-off-legacy][] |
-| [jsx/no-script-url](packages/eslint-plugin-jsx/src/rules/no-script-url.md)                                     | disallow `javascript:` URLs as JSX event handler prop's value | 👍 ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][]                                                |                                                                                                                            |                       |
-| [jsx/prefer-shorthand-boolean](packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md)               | enforce boolean attributes notation in JSX                    |                                                                                                                            | 🎨 👍 ![badge-all-legacy][] ![badge-jsx-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] | ![badge-off-legacy][] |
+| Name                                                                                                           | Description                                                   | 💼    | ⚠️     |
+| :------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------ | :---- | :---- |
+| [jsx/no-array-index-key](packages/eslint-plugin-jsx/src/rules/no-array-index-key.md)                           | disallow using Array index as key                             | 🎨 👍 |       |
+| [jsx/no-duplicate-key](packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md)                               | disallow duplicate keys in `key` prop when rendering list     | 🎨 👍 |       |
+| [jsx/no-leaked-conditional-rendering](packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md) | disallow problematic leaked values from being rendered        | 🎨 👍 |       |
+| [jsx/no-missing-key](packages/eslint-plugin-jsx/src/rules/no-missing-key.md)                                   | require `key` prop when rendering list                        | 🎨 👍 |       |
+| [jsx/no-misused-comment-in-textnode](packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md)   | disallow comments from being inserted as text nodes           |       | 🎨 👍 |
+| [jsx/no-script-url](packages/eslint-plugin-jsx/src/rules/no-script-url.md)                                     | disallow `javascript:` URLs as JSX event handler prop's value | 👍    |       |
+| [jsx/prefer-shorthand-boolean](packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md)               | enforce boolean attributes notation in JSX                    |       | 🎨 👍 |
 
 ### naming-convention
 
-| Name                                                                                                             | Description                                        | 💼 | ⚠️                     | 🚫                    |
-| :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- | :- | :-------------------- | :-------------------- |
-| [naming-convention/filename](packages/eslint-plugin-naming-convention/src/rules/filename.md)                     | enforce naming convention for JSX file names       |    | ![badge-all-legacy][] | ![badge-off-legacy][] |
-| [naming-convention/filename-extension](packages/eslint-plugin-naming-convention/src/rules/filename-extension.md) | enforces naming convention for JSX file extensions |    | ![badge-all-legacy][] | ![badge-off-legacy][] |
+| Name                                                                                                             | Description                                        | 💼 | ⚠️  |
+| :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- | :- | :- |
+| [naming-convention/filename](packages/eslint-plugin-naming-convention/src/rules/filename.md)                     | enforce naming convention for JSX file names       |    |    |
+| [naming-convention/filename-extension](packages/eslint-plugin-naming-convention/src/rules/filename-extension.md) | enforces naming convention for JSX file extensions |    |    |
 
 ### react
 
-| Name                                                                                                                                     | Description                                                                     | 💼                                                                                                | ⚠️  | 🚫                    |
-| :--------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------ | :- | :-------------------- |
-| [react/no-constructed-context-value](packages/eslint-plugin-react/src/rules/no-constructed-context-value.md)                             | disallows passing constructed values to context providers                       | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
-| [react/no-dangerously-set-innerhtml](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md)                             | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
-| [react/no-dangerously-set-innerhtml-with-children](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md) | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
-| [react/no-string-refs](packages/eslint-plugin-react/src/rules/no-string-refs.md)                                                         | disallow using deprecated string refs                                           | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
-| [react/no-unstable-default-props](packages/eslint-plugin-react/src/rules/no-unstable-default-props.md)                                   | disallow usage of unstable value as default param in function component         | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
-| [react/no-unstable-nested-components](packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md)                           | disallow usage of unstable nested components                                    | 👍 ![badge-all-legacy][] ![badge-recommended-legacy][] ![badge-recommended-type-checked-legacy][] |    | ![badge-off-legacy][] |
+| Name                                                                                                                                     | Description                                                                     | 💼 | ⚠️  |
+| :--------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------ | :- | :- |
+| [react/no-constructed-context-value](packages/eslint-plugin-react/src/rules/no-constructed-context-value.md)                             | disallows passing constructed values to context providers                       | 👍 |    |
+| [react/no-dangerously-set-innerhtml](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md)                             | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 |    |
+| [react/no-dangerously-set-innerhtml-with-children](packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md) | disallow when a DOM element is using both children and dangerouslySetInnerHTML' | 👍 |    |
+| [react/no-string-refs](packages/eslint-plugin-react/src/rules/no-string-refs.md)                                                         | disallow using deprecated string refs                                           | 👍 |    |
+| [react/no-unstable-default-props](packages/eslint-plugin-react/src/rules/no-unstable-default-props.md)                                   | disallow usage of unstable value as default param in function component         | 👍 |    |
+| [react/no-unstable-nested-components](packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md)                           | disallow usage of unstable nested components                                    | 👍 |    |
 
 <!-- end auto-generated rules list -->
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,9 @@
             "@typescript-eslint/types": "6.9.0",
             "@typescript-eslint/utils": "6.9.0",
             "@typescript-eslint/parser": ">=6.9.0"
+        },
+        "patchedDependencies": {
+            "eslint-doc-generator@1.5.2": "patches/eslint-doc-generator@1.5.2.patch"
         }
     }
 }

--- a/packages/eslint-plugin-debug/src/rules/class-component.md
+++ b/packages/eslint-plugin-debug/src/rules/class-component.md
@@ -1,4 +1,8 @@
-# @eslint-react/debug/class-component
+# debug/class-component
+
+⚠️🚫 This rule _warns_ in the `debug-legacy` config. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Warns when a class component is found. Useful for debugging.
 

--- a/packages/eslint-plugin-debug/src/rules/class-component.md
+++ b/packages/eslint-plugin-debug/src/rules/class-component.md
@@ -1,7 +1,5 @@
 # debug/class-component
 
-⚠️🚫 This rule _warns_ in the `debug-legacy` config. This rule is _disabled_ in the `off-legacy` config.
-
 <!-- end auto-generated rule header -->
 
 Warns when a class component is found. Useful for debugging.

--- a/packages/eslint-plugin-debug/src/rules/function-component.md
+++ b/packages/eslint-plugin-debug/src/rules/function-component.md
@@ -1,4 +1,8 @@
-# @eslint-react/debug/function-component
+# debug/function-component
+
+⚠️🚫 This rule _warns_ in the `debug-legacy` config. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Warns when a function component is found. Useful for debugging.
 

--- a/packages/eslint-plugin-debug/src/rules/function-component.md
+++ b/packages/eslint-plugin-debug/src/rules/function-component.md
@@ -1,7 +1,5 @@
 # debug/function-component
 
-⚠️🚫 This rule _warns_ in the `debug-legacy` config. This rule is _disabled_ in the `off-legacy` config.
-
 <!-- end auto-generated rule header -->
 
 Warns when a function component is found. Useful for debugging.

--- a/packages/eslint-plugin-jsx/src/rules/no-array-index-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-array-index-key.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/no-array-index-key
+# jsx/no-array-index-key
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule details
 

--- a/packages/eslint-plugin-jsx/src/rules/no-array-index-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-array-index-key.md
@@ -1,6 +1,6 @@
 # jsx/no-array-index-key
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md
@@ -1,6 +1,6 @@
 # jsx/no-duplicate-key
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-duplicate-key.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/no-duplicate-key
+# jsx/no-duplicate-key
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule details
 

--- a/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md
@@ -1,6 +1,6 @@
 # jsx/no-leaked-conditional-rendering
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/no-leaked-conditional-rendering
+# jsx/no-leaked-conditional-rendering
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Disallow problematic leaked values from being rendered.
 

--- a/packages/eslint-plugin-jsx/src/rules/no-missing-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-missing-key.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/no-missing-key
+# jsx/no-missing-key
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule details
 

--- a/packages/eslint-plugin-jsx/src/rules/no-missing-key.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-missing-key.md
@@ -1,6 +1,6 @@
 # jsx/no-missing-key
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/no-misused-comment-in-textnode
+# jsx/no-misused-comment-in-textnode
+
+⚠️🚫 This rule _warns_ in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 This rule prevents comment strings (e.g. beginning with `//` or `/*`) from being accidentally
 injected as a text node in JSX statements.

--- a/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-misused-comment-in-textnode.md
@@ -1,6 +1,6 @@
 # jsx/no-misused-comment-in-textnode
 
-⚠️🚫 This rule _warns_ in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+⚠️ This rule _warns_ in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-script-url.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-script-url.md
@@ -1,6 +1,6 @@
 # jsx/no-script-url
 
-💼 This rule is enabled in the following configs: 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/no-script-url.md
+++ b/packages/eslint-plugin-jsx/src/rules/no-script-url.md
@@ -1,5 +1,9 @@
 # jsx/no-script-url
 
+💼 This rule is enabled in the following configs: 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`.
+
+<!-- end auto-generated rule header -->
+
 Prevents usage of `javascript:` URLs as the value of the `href` prop in JSX.
 
 ## Rule Details

--- a/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md
+++ b/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md
@@ -1,6 +1,6 @@
 # jsx/prefer-shorthand-boolean
 
-⚠️🚫 This rule _warns_ in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+⚠️ This rule _warns_ in the following configs: 🎨 `jsx-legacy`, 👍 `recommended-legacy`.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md
+++ b/packages/eslint-plugin-jsx/src/rules/prefer-shorthand-boolean.md
@@ -1,4 +1,8 @@
-# @eslint-react/jsx/prefer-shorthand-boolean
+# jsx/prefer-shorthand-boolean
+
+⚠️🚫 This rule _warns_ in the following configs: `all-legacy`, 🎨 `jsx`, `jsx-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule Details
 

--- a/packages/eslint-plugin-naming-convention/src/rules/filename-extension.md
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename-extension.md
@@ -1,4 +1,8 @@
-# @eslint-react/naming-convention/filename-extension
+# naming-convention/filename-extension
+
+⚠️🚫 This rule _warns_ in the `all-legacy` config. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule Details
 

--- a/packages/eslint-plugin-naming-convention/src/rules/filename-extension.md
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename-extension.md
@@ -1,7 +1,5 @@
 # naming-convention/filename-extension
 
-⚠️🚫 This rule _warns_ in the `all-legacy` config. This rule is _disabled_ in the `off-legacy` config.
-
 <!-- end auto-generated rule header -->
 
 ## Rule Details

--- a/packages/eslint-plugin-naming-convention/src/rules/filename.md
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename.md
@@ -1,4 +1,8 @@
-# @eslint-react/naming-convention/filename
+# naming-convention/filename
+
+⚠️🚫 This rule _warns_ in the `all-legacy` config. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Enforces `.tsx` or `.jsx` file naming convention.
 

--- a/packages/eslint-plugin-naming-convention/src/rules/filename.md
+++ b/packages/eslint-plugin-naming-convention/src/rules/filename.md
@@ -1,7 +1,5 @@
 # naming-convention/filename
 
-⚠️🚫 This rule _warns_ in the `all-legacy` config. This rule is _disabled_ in the `off-legacy` config.
-
 <!-- end auto-generated rule header -->
 
 Enforces `.tsx` or `.jsx` file naming convention.

--- a/packages/eslint-plugin-react/src/rules/no-constructed-context-value.md
+++ b/packages/eslint-plugin-react/src/rules/no-constructed-context-value.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-constructed-context-value
+# react/no-constructed-context-value
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Prevents non-stable values (i.e. object identities) from being used as a value for Context.Provider.
 

--- a/packages/eslint-plugin-react/src/rules/no-constructed-context-value.md
+++ b/packages/eslint-plugin-react/src/rules/no-constructed-context-value.md
@@ -1,6 +1,6 @@
 # react/no-constructed-context-value
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md
+++ b/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md
@@ -1,6 +1,6 @@
 # react/no-dangerously-set-innerhtml-with-children
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md
+++ b/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml-with-children.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-dangerously-set-innerhtml-with-children
+# react/no-dangerously-set-innerhtml-with-children
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Disallow when a DOM element is using both children and `dangerouslySetInnerHTML`
 

--- a/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md
+++ b/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-dangerously-set-innerhtml-with-children
+# react/no-dangerously-set-innerhtml
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Disallow when a DOM element is using both children and `dangerouslySetInnerHTML`
 

--- a/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md
+++ b/packages/eslint-plugin-react/src/rules/no-dangerously-set-innerhtml.md
@@ -1,6 +1,6 @@
 # react/no-dangerously-set-innerhtml
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-string-refs.md
+++ b/packages/eslint-plugin-react/src/rules/no-string-refs.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-string-refs
+# react/no-string-refs
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Disallow using deprecated string refs
 

--- a/packages/eslint-plugin-react/src/rules/no-string-refs.md
+++ b/packages/eslint-plugin-react/src/rules/no-string-refs.md
@@ -1,6 +1,6 @@
 # react/no-string-refs
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-unstable-default-props.md
+++ b/packages/eslint-plugin-react/src/rules/no-unstable-default-props.md
@@ -1,6 +1,6 @@
 # react/no-unstable-default-props
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-unstable-default-props.md
+++ b/packages/eslint-plugin-react/src/rules/no-unstable-default-props.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-unstable-default-props
+# react/no-unstable-default-props
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 Disallow usage of referential-type variables as default param in function component.
 

--- a/packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md
+++ b/packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md
@@ -1,6 +1,6 @@
 # react/no-unstable-nested-components
 
-💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+💼 This rule is enabled in the 👍 `recommended-legacy` config.
 
 <!-- end auto-generated rule header -->
 

--- a/packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md
+++ b/packages/eslint-plugin-react/src/rules/no-unstable-nested-components.md
@@ -1,4 +1,8 @@
-# @eslint-react/no-unstable-nested-components
+# react/no-unstable-nested-components
+
+💼🚫 This rule is enabled in the following configs: `all-legacy`, 👍 `recommended`, `recommended-legacy`, `recommended-type-checked-legacy`. This rule is _disabled_ in the `off-legacy` config.
+
+<!-- end auto-generated rule header -->
 
 ## Rule details
 

--- a/packages/eslint-plugin/eslint-doc-generator.config.ts
+++ b/packages/eslint-plugin/eslint-doc-generator.config.ts
@@ -13,6 +13,7 @@ export default {
         ["jsx", "🎨"],
     ],
     ignoreConfig: ["all", "off", "debug", "recommended-type-checked"],
+    pathRuleDoc: (name) => `../eslint-plugin-${name.split("/")[0]}/src/rules/${name.split("/")[1]}.md`,
     pathRuleList: "../../README.md",
     ruleDocSectionInclude: ["Rule Details"],
     ruleDocTitleFormat: "name",

--- a/packages/eslint-plugin/eslint-doc-generator.config.ts
+++ b/packages/eslint-plugin/eslint-doc-generator.config.ts
@@ -7,12 +7,23 @@ const defaultTitle = "react";
 // TODO: need to modify this config to support multiple eslint-plugin packages
 export default {
     configEmoji: [
-        ["recommended", "👍"],
-        ["recommended-type-checked", "🔍"],
-        ["debug", "🛠️"],
-        ["jsx", "🎨"],
+        ["recommended-legacy", "👍"],
+        ["recommended-type-checked-legacy", "🔍"],
+        ["debug-legacy", "🛠️"],
+        ["jsx-legacy", "🎨"],
     ],
-    ignoreConfig: ["all", "off", "debug", "recommended-type-checked"],
+    ignoreConfig: [
+        "all-legacy",
+        "off-legacy",
+        "debug-legacy",
+        "recommended-type-checked-legacy",
+        "all",
+        "debug",
+        "jsx",
+        "off",
+        "recommended",
+        "recommended-type-checked",
+    ],
     pathRuleDoc: (name) => `../eslint-plugin-${name.split("/")[0]}/src/rules/${name.split("/")[1]}.md`,
     pathRuleList: "../../README.md",
     ruleDocSectionInclude: ["Rule Details"],

--- a/patches/eslint-doc-generator@1.5.2.patch
+++ b/patches/eslint-doc-generator@1.5.2.patch
@@ -1,0 +1,53 @@
+diff --git a/dist/lib/cli.js b/dist/lib/cli.js
+index d5fb61affb7439690fae7423edd7fa4f00e3218c..ed724470ebc5e34beecc0d9d2611362e0239233f 100644
+--- a/dist/lib/cli.js
++++ b/dist/lib/cli.js
+@@ -74,7 +74,9 @@ async function loadConfigFileOptions() {
+             ignoreConfig: schemaStringArray,
+             ignoreDeprecatedRules: { type: 'boolean' },
+             initRuleDocs: { type: 'boolean' },
+-            pathRuleDoc: { type: 'string' },
++            pathRuleDoc: typeof explorerResults.config.pathRuleDoc === 'function'
++                ? {}
++                : { type: 'string' },
+             pathRuleList: { anyOf: [{ type: 'string' }, schemaStringArray] },
+             postprocess: {
+             /* JSON Schema can't validate functions so check this later */
+diff --git a/dist/lib/generator.js b/dist/lib/generator.js
+index 9b08f422fd16a7ca89fa3768f002ee8eb4b6ca46..462727dc2adbdf1e9c9626114650e471b51e27d7 100644
+--- a/dist/lib/generator.js
++++ b/dist/lib/generator.js
+@@ -90,7 +90,7 @@ export async function generate(path, options) {
+     for (const [name, rule] of ruleNamesAndRules) {
+         const schema = rule.meta?.schema;
+         const description = rule.meta?.docs?.description;
+-        const pathToDoc = replaceRulePlaceholder(join(path, pathRuleDoc), name);
++        const pathToDoc = join(path, replaceRulePlaceholder(pathRuleDoc, name));
+         const ruleHasOptions = hasOptions(schema);
+         if (!existsSync(pathToDoc)) {
+             if (!initRuleDocs) {
+diff --git a/dist/lib/rule-link.js b/dist/lib/rule-link.js
+index 028101a89cc3020583fc2768a47002e9419ac446..b5b7ca1ade1b587e86bb475875e59b2a8c150d97 100644
+--- a/dist/lib/rule-link.js
++++ b/dist/lib/rule-link.js
+@@ -2,6 +2,7 @@ import { join, sep, relative, dirname } from 'node:path';
+ import { RULE_SOURCE } from './types.js';
+ import { getPluginRoot } from './package-json.js';
+ export function replaceRulePlaceholder(pathOrUrl, ruleName) {
++    if (typeof pathOrUrl === 'function') return pathOrUrl(ruleName);
+     return pathOrUrl.replace(/\{name\}/gu, ruleName);
+ }
+ /**
+diff --git a/dist/lib/types.d.ts b/dist/lib/types.d.ts
+index 17a74780d78bb62c0bac8df2f80a0d70ea787642..33e81ef093517fbd73a943013e05ca1bd109a189 100644
+--- a/dist/lib/types.d.ts
++++ b/dist/lib/types.d.ts
+@@ -137,7 +137,7 @@ export type GenerateOptions = {
+     /** Whether to create rule doc files if they don't yet exist. Default: `false`. */
+     readonly initRuleDocs?: boolean;
+     /** Path to markdown file for each rule doc. Use `{name}` placeholder for the rule name. Default: `docs/rules/{name}.md`. */
+-    readonly pathRuleDoc?: string;
++    readonly pathRuleDoc?: string | ((name: string) => string);
+     /** Path to markdown file(s) where the rules table list should live. Default: `README.md`. */
+     readonly pathRuleList?: string | readonly string[];
+     /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,11 @@ overrides:
   '@typescript-eslint/utils': 6.9.0
   '@typescript-eslint/parser': '>=6.9.0'
 
+patchedDependencies:
+  eslint-doc-generator@1.5.2:
+    hash: z4hpjazu4zrbjf5txyxe6paxni
+    path: patches/eslint-doc-generator@1.5.2.patch
+
 importers:
 
   .:
@@ -75,7 +80,7 @@ importers:
         version: 2.7.9(eslint@8.52.0)(tailwindcss@3.3.4)(typescript@5.3.0-beta)
       eslint-doc-generator:
         specifier: 1.5.2
-        version: 1.5.2(eslint@8.52.0)(typescript@5.3.0-beta)
+        version: 1.5.2(patch_hash=z4hpjazu4zrbjf5txyxe6paxni)(eslint@8.52.0)(typescript@5.3.0-beta)
       eslint-plugin-eslint-plugin:
         specifier: 5.1.1
         version: 5.1.1(eslint@8.52.0)
@@ -4147,7 +4152,7 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=9.0.0', pnpm: '>= 8.6.0'}
     dev: true
 
-  /eslint-doc-generator@1.5.2(eslint@8.52.0)(typescript@5.3.0-beta):
+  /eslint-doc-generator@1.5.2(patch_hash=z4hpjazu4zrbjf5txyxe6paxni)(eslint@8.52.0)(typescript@5.3.0-beta):
     resolution: {integrity: sha512-j+eTFcOlaKZE7h/xoQeshjzBZCW7hwKzLsS1vKsop0jfOVXIqd9uXaHXe9lCQYH4v8vGSQqaKxxrou7t22rrIg==}
     engines: {node: ^14.18.0 || ^16.0.0 || >=18.0.0}
     hasBin: true
@@ -4171,6 +4176,7 @@ packages:
       - supports-color
       - typescript
     dev: true
+    patched: true
 
   /eslint-etc@5.2.1(eslint@8.52.0)(typescript@5.3.0-beta):
     resolution: {integrity: sha512-lFJBSiIURdqQKq9xJhvSJFyPA+VeTh5xvk24e8pxVL7bwLBtGF60C/KRkLTMrvCZ6DA3kbPuYhLWY0TZMlqTsg==}


### PR DESCRIPTION
fix #21 

Because `pathRuleDoc` only supports strings as parameters, I added a [patch](https://github.com/eslint-react/eslint-react/pull/24/files#diff-326a391fda728e1bca8db7e259ce95c93d130f8c60a829fa73fca0ffdfab0401). Maybe we can submit a PR later.