### PR TITLE
fix: can not import typescript in esm

### DIFF
--- a/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
+++ b/packages/eslint-plugin-jsx/src/rules/no-leaked-conditional-rendering.ts
@@ -7,7 +7,7 @@ import { ESLintUtils } from "@typescript-eslint/utils";
 import type { ConstantCase } from "string-ts";
 import * as tsutils from "ts-api-utils";
 import { match } from "ts-pattern";
-import * as ts from "typescript";
+import ts from "typescript";
 
 import { createRule } from "../utils";
 


### PR DESCRIPTION
Run eslint

![ScreenShot 2023-11-09 18 02 14](https://github.com/eslint-react/eslint-react/assets/38493346/9a9b586a-fe34-4e2e-ba80-0404235686ab)

Can not get `ts7.TypeFlags.Null` from `import*as ts7 from"typescript"`

Because in `typescript.js` file

```
...
  // src/typescript/typescript.ts
  var require_typescript = __commonJS({
    "src/typescript/typescript.ts"(exports, module2) {
      init_ts6();
      init_ts6();
      if (typeof console !== "undefined") {
        Debug.loggingHost = {
          log(level, s) {
            switch (level) {
              case 1 /* Error */:
                return console.error(s);
              case 2 /* Warning */:
                return console.warn(s);
              case 3 /* Info */:
                return console.log(s);
              case 4 /* Verbose */:
                return console.log(s);
            }
          }
        };
      }
      module2.exports = ts_exports2;
    }
  });
  return require_typescript();
})();

if (typeof module !== "undefined" && module.exports) { module.exports = ts; }
```
